### PR TITLE
Updated the delay theme in products page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,6 +34,24 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                try {
+                  const stored = localStorage.getItem('theme');
+                  const system = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                  const theme = stored || system;
+                  document.documentElement.setAttribute('data-theme', theme);
+                  document.documentElement.style.colorScheme = theme;
+                } catch(e) {
+                  document.documentElement.setAttribute('data-theme', 'dark');
+                  document.documentElement.style.colorScheme = 'dark';
+                }
+              })();
+            `,
+          }}
+        />
         <ThemeScript />
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} ${inter.variable} antialiased`}>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -68,6 +68,11 @@ const productCatalog = [
 
 export default function Navbar() {
   const { theme, toggleTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
   const isDark = theme === 'dark';
   const [mobileOpen, setMobileOpen] = useState(false);
   const [servicesOpen, setServicesOpen] = useState(false);
@@ -287,30 +292,38 @@ export default function Navbar() {
               }}
               aria-label="Toggle color theme"
               role="switch"
-              aria-checked={theme === 'dark'}
+              aria-checked={mounted ? theme === 'dark' : false}
               className="theme-toggle"
             >
               <span className="sr-only">
-                {theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+                {mounted
+                  ? theme === 'dark'
+                    ? 'Switch to light mode'
+                    : 'Switch to dark mode'
+                  : 'Toggle color theme'}
               </span>
               {/* Icons */}
               <SunIcon
                 aria-hidden
                 className="absolute left-2 h-4 w-4 transition-colors"
-                style={{ color: theme === 'dark' ? 'var(--text-primary)' : 'var(--text-primary)' }}
+                style={{ color: 'var(--text-primary)' }}
               />
               <MoonIcon
                 aria-hidden
                 className="absolute right-2 h-4 w-4 transition-colors"
                 style={{
-                  color: theme === 'dark' ? 'var(--text-primary)' : 'var(--text-secondary)',
+                  color: mounted
+                    ? theme === 'dark'
+                      ? 'var(--text-primary)'
+                      : 'var(--text-secondary)'
+                    : 'var(--text-secondary)',
                 }}
               />
               {/* Knob */}
               <motion.span
                 aria-hidden
                 className="theme-toggle-knob"
-                animate={{ x: theme === 'dark' ? 32 : 0 }}
+                animate={{ x: mounted ? (theme === 'dark' ? 32 : 0) : 0 }}
                 transition={{ type: 'spring', stiffness: 500, damping: 32 }}
               />
             </button>


### PR DESCRIPTION
The theme flash is still happening because the ThemeScript sets the theme on the document element, but there's still a brief moment where the server-rendered content shows before the client-side theme is applied. Let me fix this by improving the theme initialization strategy.