### PR TITLE
Committed the contact icon

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -566,6 +566,42 @@ body {
   background: linear-gradient(90deg, transparent, var(--accent-2), transparent);
 }
 
+/* Keep input icons vertically centered regardless of helper/error text */
+.contact-form .relative {
+  padding-bottom: 1.5rem; /* reserve space for potential error text */
+  position: relative; /* ensure a containing block for absolute children */
+}
+
+.contact-form .relative [role='alert'] {
+  position: absolute;
+  bottom: 0.25rem; /* keep inside reserved padding area */
+  left: 0; /* anchor to field edge */
+  padding-left: 2.5rem; /* align message text with input text start */
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  font-weight: 500;
+  color: var(--destructive, #ef4444);
+  pointer-events: none; /* do not steal focus */
+  z-index: 1;
+}
+
+/* Force icons inside fields to be vertically centered */
+.contact-form .relative > span.pointer-events-none {
+  top: 50% !important;
+  transform: translateY(-50%) !important;
+}
+
+/* Standardize icon sizing for consistency */
+.contact-form .relative > span.pointer-events-none svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+/* Textarea icon matches input centering for symmetry */
+
 .contact-form-dark {
   background-color: rgba(255, 255, 255, 0.08);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
@@ -582,6 +618,8 @@ body {
   backdrop-filter: blur(8px);
   transition: all 0.3s ease;
   font-weight: 500;
+  line-height: 1.5;
+  min-height: 44px; /* consistent control height for alignment & tap target */
 }
 
 .form-input:hover {
@@ -594,7 +632,6 @@ body {
   border-color: var(--accent-2);
   background-color: var(--surface-1);
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
-  transform: translateY(-1px);
 }
 
 .form-input::placeholder {


### PR DESCRIPTION
ncreased reserved space under each field to prevent crowding when warnings show.
Anchored warnings to the left edge but padded them so the text aligns with the input text (not the icon).
Standardized warning layout with flex, small gap, and consistent font size/weight; disabled pointer events so they don’t grab focus.